### PR TITLE
Bugfix in constructor

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -9,7 +9,7 @@ struct OneHotArray{N,A} <: AbstractArray{Bool,N}
     q::Int
     function OneHotArray(c::Union{Int, AbstractArray{Int}}, q::Int = maximum(c))
         if !all(1 ≤ x ≤ q for x in c)
-            throw(ArgumentError("c must be ≥ 1 and ≤ $q; got $x"))
+            throw(ArgumentError("c must be ≥ 1 and ≤ $q; got $c"))
         end
         return new{ndims(c) + 1, typeof(c)}(c, q)
     end


### PR DESCRIPTION
After this, the following would work:
```julia
julia> OneHotArray(10, 2)
ERROR: ArgumentError: c must be ≥ 1 and ≤ 2; got 10
Stacktrace:
 [1] OneHotArray(c::Int64, q::Int64)
   @ OneHot ~/.julia/dev/OneHot/src/array.jl:12
 [2] top-level scope
   @ REPL[5]:1
```